### PR TITLE
Handle the case when an exception is thrown inside get_logstash_results

### DIFF
--- a/lib/nagios-herald/formatters/check_logstash.rb
+++ b/lib/nagios-herald/formatters/check_logstash.rb
@@ -22,6 +22,12 @@ module NagiosHerald
         logstash_helper = NagiosHerald::Helpers::LogstashQuery.new
         results = get_logstash_results(logstash_helper, command_components[:query])
 
+        # Handle the case when an exception is thrown inside get_logstash_results
+        if results.empty?
+          add_text(section, "Something went wrong while getting logstash results\n\n")
+          return
+        end
+
         if results["hits"]["hits"].empty? && results["aggregations"]
           # We have aggregations
 


### PR DESCRIPTION
Hi,
I fell in a situation where elasticsearch was not running and an unhandled exception caused undelivered nagios notification emails. The exact error in nagios-herald log was [FATAL] can't convert String into Integer (TypeError). This is a simple workaround but you can enrich it as much as you want of course.

Regards
