### PR TITLE
Add option to draw 'absolute' data set (not percentage) - 

### DIFF
--- a/bin/draw_stack_bars
+++ b/bin/draw_stack_bars
@@ -35,6 +35,15 @@ def drawStackBars(series, options):
     stacked_bars.render(series)
     stacked_bars.save(options.get('output_file'))
 
+def setDefaultColors(options):
+    #import pdb;pdb.set_trace()
+    if options.draw_mode == "percentage":
+        options.full_color = options.full_color or '#00e600'
+        options.empty_color = options.empty_color or '#FF0000'
+    elif options.draw_mode == "absolute":
+        options.full_color = options.full_color or '#3333ff'
+    return options
+
 def parse_options():
     usage = "usage: %prog [options] label=value label=value"
 
@@ -60,11 +69,31 @@ def parse_options():
                     help="Width of the border around the bars",
                     dest="bar_border", default=1)
 
+    parser.add_option("-m", "--mode", type="choice",
+                    help="Drawing mode : percentage, absolute",
+                    choices = ['percentage', 'absolute'],
+                    dest="draw_mode", default="percentage")
+
+    parser.add_option("--full-color", type="string",
+                    help="Color for full bars (eg. #00e600)",
+                    dest="full_color")
+
+    parser.add_option("--empty-color", type="string",
+                    help="Color for empty bars (eg. #00e600)",
+                    dest="empty_color")
+
+    parser.add_option("--font", type="choice",
+                    help="Font to use",
+                    choices = ['aerial', 'arial_black', 'Tahoma'],
+                    dest="font_name", default = "arial_black")
+
+
     options, data = parser.parse_args()
     if not data:
         sys.stderr.write("No  data to plot !\n\n")
         parser.print_help()
         sys.exit(1)
+    options = setDefaultColors(options)
     return options, data
 
 if __name__=='__main__':

--- a/lib/stackbars/stackbar.py
+++ b/lib/stackbars/stackbar.py
@@ -3,17 +3,17 @@ from PIL import ImageFont
 from chart_utils import get_optimal_font_size, get_font
 
 class Stackbar:
-    def __init__(self, draw, legend, fill_value, options = {}):
-
-        assert fill_value <= 100, "Invalid fill value - must be <= 100"
-
+    def __init__(self, draw, legend, data_value, fill_value, options = {}):
         self.legend = legend
+        self.data_value = data_value
         self.fill_value = fill_value
 
         self.border = options.get('bar_border', 1)
-        self.full_color = options.get('green', (255, 0, 0))
-        self.empty_color = options.get('red', (0, 255, 0))
-        self.font_type = options.get('font_type', get_font('arial_black.ttf'))
+        self.full_color = options.get('full_color', (255, 0, 0))
+        self.empty_color = options.get('empty_color', (0, 255, 0))
+
+        font_name = "%s.ttf" % options.get('font_name', 'arial_black')
+        self.font_type =  get_font(font_name)
 
         self.light_font_color = options.get('fontcolor', (255, 255, 255))
         self.dark_font_color = options.get('fontcolor', (0, 0, 0))
@@ -29,18 +29,17 @@ class Stackbar:
         self.draw.rectangle((full_top_left, full_bottom_right), fill=self.full_color)
 
         # Draw text
-        rect_label = "%i%%" % self.fill_value
-        optimal_font_size = get_optimal_font_size(self.draw, self.font_type, rect_width, bar_height, rect_label, 7, font_size)
+        optimal_font_size = get_optimal_font_size(self.draw, self.font_type, rect_width, bar_height, self.data_value, 7, font_size)
         if not optimal_font_size:
             return
 
         font = ImageFont.truetype(self.font_type, optimal_font_size)
-        label_width, label_height = self.draw.textsize(rect_label, font=font)
+        label_width, label_height = self.draw.textsize(self.data_value, font=font)
         label_margin = (rect_width - label_width) / 2
         label_offset = (bar_height - label_height) / 2
         self.draw.text(
             (self.border + 1 + label_margin, height_offset + self.border + 1 + label_offset),
-            rect_label,
+            self.data_value,
             font=font,
             fill=self.light_font_color
         )
@@ -85,7 +84,7 @@ class Stackbar:
     def drawBase(self, width, bar_height, height_offset):
         self.draw.rectangle((0,height_offset, width, height_offset + bar_height), fill=(0,0,0))
 
-    def render(self, width, height_offset, bars_width, bar_height, font_size, draw_bottom_border = True):
+    def render_percentage(self, width, height_offset, bars_width, bar_height, font_size, draw_bottom_border = True):
         if draw_bottom_border:
             bottom_border_offset = 1
         else:
@@ -96,5 +95,19 @@ class Stackbar:
         self.drawFullRectangle(bars_width, bar_height, height_offset, font_size - 1, bottom_border_offset)
 
         self.drawEmptyRectangle(bars_width, bar_height, height_offset, font_size - 1, bottom_border_offset)
+
+        self.drawLegend(bars_width, bar_height, height_offset, font_size)
+
+    def render_absolute(self, width, height_offset, bars_width, bar_height, font_size, draw_bottom_border = True):
+        if draw_bottom_border:
+            bottom_border_offset = 1
+        else:
+            bottom_border_offset = 0
+
+        #self.drawBase(bars_width, bar_height, height_offset)
+
+        self.drawFullRectangle(bars_width, bar_height, height_offset, font_size - 1, bottom_border_offset)
+
+        #self.drawEmptyRectangle(bars_width, bar_height, height_offset, font_size - 1, bottom_border_offset)
 
         self.drawLegend(bars_width, bar_height, height_offset, font_size)


### PR DESCRIPTION
aka simple …bar charts

I needed to show bar charts that were not percentages of a total. You can create such bar chart as follow:

```./bin/draw_stack_bars -o foo.png "first label"=180 "another label"=50 --mode absolute```

This PR also exposes additional options:
* font
* full_color
* empty_color
