### PR TITLE
Removing Helpers namespace to standardize on Helper

### DIFF
--- a/bin/get_ganglia_graph
+++ b/bin/get_ganglia_graph
@@ -76,7 +76,7 @@ abort("Config file not found #{options.config_file}") unless File.exists? option
 config = AppConf.new
 config.load( options.config_file )
 
-ganglia = NagiosHerald::Helpers::GangliaGraph.new
+ganglia = NagiosHerald::Helper::GangliaGraph.new
 
 image_paths = ganglia.get_graphs( options.hosts, options.metric, options.path, options.range )
 puts image_paths.join( ", " ) if image_paths

--- a/bin/get_graph
+++ b/bin/get_graph
@@ -46,5 +46,5 @@ end
 path = Choice[:path] if Choice[:path]
 uris = Choice[:uris] if Choice[:uris]
 
-image_paths = NagiosHerald::Helpers::UrlImage.download_images( uris, path )
+image_paths = NagiosHerald::Helper::UrlImage.download_images( uris, path )
 puts image_paths.join( ", " )

--- a/bin/get_graphite_graph
+++ b/bin/get_graphite_graph
@@ -53,6 +53,6 @@ historical_graph = true if Choice[:historical_graph]
 path = Choice[:path]
 uri = Choice[:uri]
 
-graphite = NagiosHerald::Helpers::GraphiteGraph.new
+graphite = NagiosHerald::Helper::GraphiteGraph.new
 image_paths = graphite.get_graph(uri, path, historical_graph)
 puts image_paths.join(", ") if image_paths

--- a/bin/splunk_alert_frequency
+++ b/bin/splunk_alert_frequency
@@ -49,6 +49,6 @@ end
 config  = AppConf.new
 config.load( Choice[:config_file] )
 
-reporter = NagiosHerald::Helpers::SplunkReporter.new(config['splunk']['url'],config['splunk']['username'], config['splunk']['password'])
+reporter = NagiosHerald::Helper::SplunkReporter.new(config['splunk']['url'],config['splunk']['username'], config['splunk']['password'])
 puts reporter.get_alert_frequency(Choice[:hostname], Choice[:service_name], {:duration => Choice[:duration]})
 

--- a/lib/nagios-herald/formatters/check_elasticsearch.rb
+++ b/lib/nagios-herald/formatters/check_elasticsearch.rb
@@ -20,7 +20,7 @@ module NagiosHerald
         # The aggregation level limit for which we can render results
         agg_level_limit = 3
 
-        elasticsearch_helper = NagiosHerald::Helpers::ElasticsearchQuery.new({ :time_period => command_components[:time_period]})
+        elasticsearch_helper = NagiosHerald::Helper::ElasticsearchQuery.new({ :time_period => command_components[:time_period]})
         results = get_elasticsearch_results(elasticsearch_helper, command_components[:query])
 
         # Handle the case when an exception is thrown inside get_elasticsearch_results

--- a/lib/nagios-herald/formatters/check_graphite_graph.rb
+++ b/lib/nagios-herald/formatters/check_graphite_graph.rb
@@ -12,7 +12,7 @@ module NagiosHerald
       # Returns the file names of all retrieved graphs. These can be attached to the message.
       def get_graphite_graphs(url)
         begin
-          graphite = NagiosHerald::Helpers::GraphiteGraph.new
+          graphite = NagiosHerald::Helper::GraphiteGraph.new
           show_historical = true
           graphs =  graphite.get_graph(url, @sandbox, show_historical)
           return graphs

--- a/lib/nagios-herald/helpers/alert_frequency.rb
+++ b/lib/nagios-herald/helpers/alert_frequency.rb
@@ -81,7 +81,7 @@ module NagiosHerald
       def get_alert_frequency(query)
         # Call elasticsearch_query.rb here
         options = {:time_period => @time_period, :num_results => @num_results}
-        es = NagiosHerald::Helpers::ElasticsearchQuery.new(options)
+        es = NagiosHerald::Helper::ElasticsearchQuery.new(options)
         results = es.query_from_string(query)
 
         events_count = aggregate_events(results)

--- a/lib/nagios-herald/helpers/ganglia_graph.rb
+++ b/lib/nagios-herald/helpers/ganglia_graph.rb
@@ -86,7 +86,7 @@ module NagiosHerald
           cluster_name = get_cluster_name_for_host(host)
           url = get_ganglia_url(cluster_name, host, metric, range)
           image_path = "#{path}/#{host}-#{metric}.png"
-          success = NagiosHerald::Helpers::UrlImage.download_image(url, image_path)
+          success = NagiosHerald::Helper::UrlImage.download_image(url, image_path)
           if success
             image_paths.push( image_path )
           else

--- a/lib/nagios-herald/helpers/graphite_graph.rb
+++ b/lib/nagios-herald/helpers/graphite_graph.rb
@@ -24,7 +24,7 @@ module NagiosHerald
       #
       # Returns nothing. Appends the downloaded image path to @image_paths.
       def download_image(url, download_path)
-        success = NagiosHerald::Helpers::UrlImage.download_image(url, download_path)
+        success = NagiosHerald::Helper::UrlImage.download_image(url, download_path)
         if success
           @image_paths.push(download_path)
         else

--- a/lib/nagios-herald/helpers/splunk_query.rb
+++ b/lib/nagios-herald/helpers/splunk_query.rb
@@ -21,9 +21,9 @@ module NagiosHerald
       #
       # Example:
       #
-      # splunk_query = NagiosHerald::Helpers::SplunkQuery.new('sourcetype=perf_log page=index.html')
-      # splunk_query = NagiosHerald::Helpers::SplunkQuery.new('transaction_state=paid', {:index => 'get_paid'})
-      # splunk_query = NagiosHerald::Helpers::SplunkQuery.new('source=nagios-herald.log alert_type=host', {:output => 'csv'})
+      # splunk_query = NagiosHerald::Helper::SplunkQuery.new('sourcetype=perf_log page=index.html')
+      # splunk_query = NagiosHerald::Helper::SplunkQuery.new('transaction_state=paid', {:index => 'get_paid'})
+      # splunk_query = NagiosHerald::Helper::SplunkQuery.new('source=nagios-herald.log alert_type=host', {:output => 'csv'})
       #
       # Returns a new SplunkQuery object.
       def initialize(query, options={})

--- a/lib/nagios-herald/version.rb
+++ b/lib/nagios-herald/version.rb
@@ -1,3 +1,3 @@
 module NagiosHerald
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/test/unit/formatters/test_check_elasticsearch.rb
+++ b/test/unit/formatters/test_check_elasticsearch.rb
@@ -1,0 +1,43 @@
+require 'minitest/autorun'
+
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', '..', '..', 'lib')
+require 'nagios-herald'
+require 'nagios-herald/config'
+require 'nagios-herald/executor'
+require 'nagios-herald/formatters/base'
+
+# Test Formatter::CheckElasticsearch
+class TestFormatterCheckElasticsearch < MiniTest::Unit::TestCase
+
+  # TODO: We need a similar set of tests for RECOVERY emails.
+  # Initial setup before we execute tests
+  def setup
+    @options = {}
+    @options[:message_type] = 'EMAIL'
+    @options[:nagios_url] = "http://nagios.example.com"
+    @options[:formatter_name] = 'check_elasticsearch'
+    env_file = File.join(File.dirname(__FILE__), '..', '..', 'env_files', 'check_elasticsearch.WARNING')
+    NagiosHerald::Executor.new.load_env_from_file(env_file) # load an env file for testing
+    NagiosHerald::Executor.new.load_formatters
+    NagiosHerald::Executor.new.load_messages
+    formatter_class = NagiosHerald::Formatter.formatters[@options[:formatter_name]]
+    @formatter = formatter_class.new(@options)
+  end
+
+  def teardown
+    # make certain we don't leave tons of empty temp dirs behind
+    @formatter.clean_sandbox
+  end
+
+  # Test that we have a new NagiosHerald::Formatter object.
+  def test_new_formatter
+    assert_instance_of NagiosHerald::Formatter::CheckElasticsearch, @formatter
+  end
+
+  def test_clean_sandbox
+    @formatter.clean_sandbox
+    assert !File.directory?(@formatter.sandbox)
+  end
+
+end
+


### PR DESCRIPTION
It turned out that we had two namespaces for helpers - Helper and Helpers. The helpers themselves all use Helper, but other formatters and helpers were using Helpers. Not only is this confusing, but it's inconsistent with how the Formatter and Message namespaces are used. This commit changes this to properly reference Helper, and adds an example of a test case that might have caught this. 