### PR TITLE
Check elasticsearch improvements

### DIFF
--- a/etc/config.yml.example
+++ b/etc/config.yml.example
@@ -10,6 +10,7 @@ elasticsearch:
   url: http://logstash.example.com:9200
   frontend_url: https://kibana.example.com/#/dashboard/file/logstash.json?from=%{from}&to=%{to}&query=%{query}
   result_field_truncate: 200
+  fields_in_email: [ message, host, type, etsy_user_id, etsy_request_uuid ]
   num_results: 10
 logfile: /tmp/nagios-herald.log
 formatter_dir: /usr/local/nagios-herald-formatters

--- a/lib/nagios-herald/formatters/check_elasticsearch.rb
+++ b/lib/nagios-herald/formatters/check_elasticsearch.rb
@@ -73,7 +73,7 @@ module NagiosHerald
           service_output = get_nagios_var("NAGIOS_SERVICECHECKCOMMAND")
           command_components =  parse_command(service_output)
 
-          frontend_url_format = NagiosHerald::Config.config['elasticsearch']['frontend_url']
+          frontend_url_format = Config.config['elasticsearch']['frontend_url']
 
           if !frontend_url_format.nil? and !frontend_url_format.empty?
             bounds = get_frontend_bounds_from_time_period(command_components[:time_period])
@@ -176,7 +176,7 @@ module NagiosHerald
         output_prefix = "<table border='1' cellpadding='0' cellspacing='1'>"
         output_suffix = "</table>"
 
-        fields_in_config = NagiosHerald::Config.config['elasticsearch']['fields_in_email']
+        fields_in_config = Config.config['elasticsearch']['fields_in_email']
 
         if fields_in_config.nil?
             fields = results.first['_source'].keys

--- a/lib/nagios-herald/formatters/check_elasticsearch.rb
+++ b/lib/nagios-herald/formatters/check_elasticsearch.rb
@@ -176,9 +176,17 @@ module NagiosHerald
         output_prefix = "<table border='1' cellpadding='0' cellspacing='1'>"
         output_suffix = "</table>"
 
-        headers = "<tr>#{results.first["_source"].keys.map{|h|"<th>#{h}</th>"}.join}</tr>"
-        result_values = results.map{|r|r["_source"]}
+        fields_in_config = NagiosHerald::Config.config['elasticsearch']['fields_in_email']
 
+        if fields_in_config.nil?
+            fields = results.first['_source'].keys
+        else
+            fields = results.first['_source'].keys & fields_in_config
+        end
+
+        headers = "<tr>#{fields.map{|h|"<th>#{h}</th>"}.join}</tr>"
+
+        result_values = results.map{|r| r["_source"].select {|key, val| fields.include? key} }
         body = result_values.map{|r| "<tr>#{r.map{|k,v|"<td>#{v}</td>"}.join}</tr>"}.join
 
         output_prefix + headers + body + output_suffix

--- a/lib/nagios-herald/messages/email.rb
+++ b/lib/nagios-herald/messages/email.rb
@@ -118,6 +118,7 @@ module NagiosHerald
 
         html_part = Mail::Part.new do
           content_type 'multipart/related;'
+          content_transfer_encoding 'quoted-printable'
         end
 
         # Load the attachments
@@ -131,6 +132,7 @@ module NagiosHerald
           inline_html = inline_body_with_attachments(html_part.attachments)
           html_content_part = Mail::Part.new do
             content_type 'text/html; charset=UTF-8'
+            content_transfer_encoding 'quoted-printable'
             body     inline_html
           end
           html_part.add_part(html_content_part)

--- a/test/integration/test_message_email.rb
+++ b/test/integration/test_message_email.rb
@@ -62,7 +62,7 @@ class TestMessageEmail < MiniTest::Unit::TestCase
     assert_match "text/plain", mail.text_part.content_type
   end
 
-  def xtest_message_delivery
+  def test_message_delivery
     # This test depends on the mailcatcher gem being installed and
     # `mailcatcher` running. `mailcatcher` runs locally on tcp/1025.
     # NOTE: NagiosHerald::Message::Email#send calls #build_message before

--- a/test/integration/test_message_email.rb
+++ b/test/integration/test_message_email.rb
@@ -51,7 +51,18 @@ class TestMessageEmail < MiniTest::Unit::TestCase
     assert_instance_of NagiosHerald::Message::Email, @message
   end
 
-  def test_message_delivery
+  def test_html_part_content_type_and_encoding
+    mail = @message.build_message
+    assert_match "text/html", mail.html_part.content_type
+    assert_equal mail.html_part.content_transfer_encoding, 'quoted-printable'
+  end
+
+  def test_plain_part_content_type
+    mail = @message.build_message
+    assert_match "text/plain", mail.text_part.content_type
+  end
+
+  def xtest_message_delivery
     # This test depends on the mailcatcher gem being installed and
     # `mailcatcher` running. `mailcatcher` runs locally on tcp/1025.
     # NOTE: NagiosHerald::Message::Email#send calls #build_message before


### PR DESCRIPTION
- filter fields that get shown in check_elasticsearch check

    This adds a new config option called fields_in_email under elasticsearch
    that optionally filters the fields that get shown in a check elasticsearch
    email.

- add content_transfer_encoding to html emails

    By default this is set to 7bit, and this places a limit on how long
    lines can be in an email.

    Since our HTML emails can have lines that are really long, the 7 bit
    encoding doesn't really work. Mail clients will insert whitespace after
    1000 characters, and this messes up links in the email.

    There's a better explanation here:
    http://stackoverflow.com/questions/25710599/content-transfer-encoding-7bit-or-8-bit