### PR TITLE
use quoted-printable encoding

### DIFF
--- a/lib/nagios-herald/messages/email.rb
+++ b/lib/nagios-herald/messages/email.rb
@@ -118,6 +118,7 @@ module NagiosHerald
 
         html_part = Mail::Part.new do
           content_type 'multipart/related;'
+          content_transfer_encoding 'quoted-printable'
         end
 
         # Load the attachments


### PR DESCRIPTION
Use quoted-printable encoding for HTML parts to work around https://github.com/mikel/mail/issues/316. This issue is fixed in Mail 2.6.x but this change is forward-compatible with it.